### PR TITLE
ci: add release-please for pioneer component

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,19 @@
+name: release-please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v5
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,3 @@
+{
+  "components/pioneer": "0.3.0"
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "simple",
+  "include-component-in-tag": true,
+  "include-v-in-tag": true,
+  "separate-pull-requests": true,
+  "packages": {
+    "components/pioneer": {
+      "component": "pioneer",
+      "package-name": "pioneer"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `release-please` GitHub Action (v5) configured in manifest mode
- Configure `components/pioneer` as a `simple` release-type package, pinned at `0.3.0`
- Tags will be cut as `pioneer-v<version>` from conventional commits touching `components/pioneer/**`

Other components (`plaato_airlock`, `remote_base`) are not yet wired in — they can be added to `release-please-config.json` and `.release-please-manifest.json` when ready.

## Test plan
- [ ] Merge to `main` and confirm the workflow opens a release PR for `pioneer`
- [ ] Confirm merging that release PR creates the `pioneer-v0.3.0` tag and GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)